### PR TITLE
datetimeカラムが不足しているログを修正するタスクを実装

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -7,14 +7,11 @@ class Log
   field :room,        type: String
   field :text,        type: String
   field :user,        type: Hash
+  field :datetime,    type: Time
   alias_attribute :raw_message, :rawMessage
   alias_attribute :raw_text,    :rawText
 
   paginates_per 30
-
-  def datetime
-    Time.at(raw_message[:ts].to_i)
-  end
 
   default_scope -> { order_by(id: 'desc') }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,16 +17,6 @@ Bundler.require(*Rails.groups)
 
 module SlackLogViewer
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/lib/tasks/lacking_log.rake
+++ b/lib/tasks/lacking_log.rake
@@ -1,0 +1,10 @@
+namespace :lacking_log do
+  desc 'datetimeが存在しないドキュメントにdatetimeを追加'
+  task add_datetime: :environment do
+    Log.all.map do |log|
+      if log.datetime == nil
+        log.update_attribute(:datetime, Time.at(log.raw_message[:ts].to_i))
+      end
+    end
+  end
+end


### PR DESCRIPTION
デプロイ後に
`heroku run bin/rake lacking_log:add_datetime`
を実行
